### PR TITLE
Mark obsolete and point to openwrt/packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 # Clixon openwrt feed
 
+_This repository has been obsoleted in favor of git://github.com/openwrt/packages.git which now includes both Cligen and Clixon._
+
 ## Description
 
 This repo contains an OpenWrt package feed containing clixon related libraries and applications.


### PR DESCRIPTION
No longer need a separate repo.
